### PR TITLE
Added the http status code into the errorcode structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ Default: `./codes.json` _codes.json from inside `lib` directory_
 
 File path to your own custom error codes.
 
+#### Reference
+http status code: http://www.restapitutorial.com/httpstatuscodes.html
+
+

--- a/index.js
+++ b/index.js
@@ -15,3 +15,17 @@ exports.next400 = function(codes) {
   var max = Math.max.apply(null, fourSeries);
   return max + 1;
 };
+
+// next available 500-space code
+exports.next500 = function(codes) {
+  var fiveSeries = [];
+
+  for (var k in codes) {
+    if (codes[k].code >= 5000000) {
+      fiveSeries.push(codes[k].code);
+    }
+  }
+
+  var max = Math.max.apply(null, fiveSeries);
+  return max + 1;
+};

--- a/lib/codes.json
+++ b/lib/codes.json
@@ -1,5 +1,14 @@
 {
+  "AccessTokenExpired": {
+    "status": 401,
+    "code": 4000005,
+    "error": "access_token_expired",
+    "description": {
+      "en": "Your access token has expired. You can request a new access token with refresh token. "
+    }
+  },
   "EmailAlreadyInUse": {
+    "status": 409,
     "code": 4000001,
     "error": "email_already_in_use",
     "description": {
@@ -9,6 +18,7 @@
     }
   },
   "RefreshTokenRequired": {
+    "status": 400,
     "code": 4000004,
     "error": "refresh_token_required",
     "description": {
@@ -16,6 +26,7 @@
     }
   },
   "Unknown": {
+    "status": 500,
     "code": 5000001,
     "error": "unknown",
     "description": {
@@ -23,6 +34,7 @@
     }
   },
   "UnknownErrorId": {
+    "status": 500,
     "code": 5000002,
     "error": "unknown_error_id",
     "description": {
@@ -30,6 +42,7 @@
     }
   },
   "UserCredentialsRequired": {
+    "status": 400,
     "code": 4000003,
     "error": "user_credentials_required",
     "description": {
@@ -37,6 +50,7 @@
     }
   },
   "UsernameUnavailable": {
+    "status": 409,
     "code": 4000002,
     "error": "username_unavailable",
     "description": {

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ module.exports = function (options) {
     var codes = require(option.value.codes);
 
     var venzeeError = codes[err.id];
+    status = venzeeError.status;
 
     // NOT COOL
     if (!venzeeError && !production) {
@@ -34,10 +35,6 @@ module.exports = function (options) {
       venzeeError.description.en = venzeeError.description.en + ': ' + err.id;
       err.id = 'UnknownErrorId';
       status = 500;
-    }
-
-    if (venzeeError.code < 5000000) {
-      status = 400;
     }
 
     res.statusCode = status;

--- a/tasks/config/prompt.js
+++ b/tasks/config/prompt.js
@@ -4,6 +4,11 @@ module.exports = {
     options: {
       questions: [
         {
+          config: 'vcodes.options.statuscode',
+          type: 'input',
+          message: 'HTTP status code (e.g., 400, 401, 500):'
+        },
+        {
           config: 'vcodes.options.name',
           type: 'input',
           message: 'Error code name:'

--- a/tasks/update-codes.js
+++ b/tasks/update-codes.js
@@ -5,6 +5,7 @@ module.exports = function (grunt) {
   grunt.registerTask('update-codes',
     'Update the known Venzee error codes.', function () {
 
+      var newStatusCode = grunt.config('vcodes.options.statuscode');
       var newName = grunt.config('vcodes.options.name');
       var newMessage = grunt.config('vcodes.options.message');
 
@@ -18,10 +19,18 @@ module.exports = function (grunt) {
 
         var codes = grunt.file.readJSON('./lib/codes.json');
 
-        var nextCode = require('../').next400(codes);
+        var statusCode = newStatusCode - 0;
+        var nextCode;
+        if (statusCode < 500) {
+          nextCode = require('../').next400(codes);
+        } else {
+          nextCode = require('../').next500(codes);
+        }
+
 
         // add the code to the list!
         codes[bumpy] = {
+          status: statusCode,
           code: nextCode,
           error: snake,
           description: {


### PR DESCRIPTION
 Per Ryan's request, " @ryandrewjohnson  [5:58 PM] 
Thanks @xin-usa much appreciated. I've googled around to see what the typical http status code is for expired tokens and it seems it's a typical 401 unauthorized. So I'd most likely need to use the custom error code to differentiate between a normal 401 and a 401 from an expired token." 

@claylo :
I have added the http status code into the code structure. As we discussed during the weekend, we also see some best practice in adding the status code into the code structure, in order to refine the detail of errors. Let me know whether this looks okay. Thanks for writing up the venzee-error-handler module. It's fantastic!
